### PR TITLE
Fix client pages unauthorized errors by adding token headers

### DIFF
--- a/WebApp/Pages/ClientesPages/NuevaTransaccion.cshtml
+++ b/WebApp/Pages/ClientesPages/NuevaTransaccion.cshtml
@@ -36,10 +36,10 @@
 
 
 
-<script src="~/js/ControlActions.js"></script>
-
-
-
 @section Scripts {
+    <script>
+        var userToken = '@HttpContext.Request.Cookies["jwt_token"]';
+    </script>
+    <script src="~/js/ControlActions.js"></script>
     <script src="~/js/Pages/ClientesPages/NuevaTransaccion.js" asp-append-version="true"></script>
 }

--- a/WebApp/wwwroot/js/ControlActions.js
+++ b/WebApp/wwwroot/js/ControlActions.js
@@ -1,6 +1,15 @@
 ﻿function ControlActions() {
-	//Ruta base del API
-	this.URL_API = "https://localhost:5001/api/";
+        //Ruta base del API
+        this.URL_API = "https://localhost:5001/api/";
+
+        // Configura el header de autorización para todas las solicitudes AJAX si existe un token
+        if (typeof userToken !== 'undefined' && userToken) {
+                $.ajaxSetup({
+                        headers: {
+                                'Authorization': 'Bearer ' + userToken
+                        }
+                });
+        }
 
 	this.GetUrlApiService = function (service) {
 		return this.URL_API + service;

--- a/WebApp/wwwroot/js/Pages/ClientesPages/ClienteHome.js
+++ b/WebApp/wwwroot/js/Pages/ClientesPages/ClienteHome.js
@@ -23,7 +23,13 @@ function ClienteHomePage() {
         const url = ca.GetUrlApiService(`${this.apiCuenta}/RetrieveAll?clienteId=${this.getClienteId()}`);
         $('#tblCuentasHome').DataTable({
             destroy: true,
-            ajax: { url: url, dataSrc: '' },
+            ajax: {
+                url: url,
+                dataSrc: '',
+                headers: {
+                    'Authorization': 'Bearer ' + userToken
+                }
+            },
             columns: [
                 { data: 'banco' },
                 { data: 'tipoCuenta' },
@@ -37,7 +43,13 @@ function ClienteHomePage() {
         const url = ca.GetUrlApiService(`${this.apiTrans}/RetrieveByCliente?clienteId=${this.getClienteId()}`);
         $('#tblUltimasTransacciones').DataTable({
             destroy: true,
-            ajax: { url: url, dataSrc: '' },
+            ajax: {
+                url: url,
+                dataSrc: '',
+                headers: {
+                    'Authorization': 'Bearer ' + userToken
+                }
+            },
             columns: [
                 { data: 'fecha' },
                 { data: 'metodoPago' },


### PR DESCRIPTION
## Summary
- Configure ControlActions to attach Authorization header to all AJAX requests when a JWT is present
- Ensure ClienteHome data tables send the user token with API calls
- Inject JWT token into NuevaTransaccion page scripts for authenticated API access

## Testing
- `dotnet test`
- `dotnet build` *(fails: RetrieveById overrides missing in DataAccess project)*

------
https://chatgpt.com/codex/tasks/task_e_68924085f8a4832ca43019c4bbe6f51f